### PR TITLE
feat:評論改用pinia管理、個人頁引入評論

### DIFF
--- a/src/components/storeComment/CommentInput.vue
+++ b/src/components/storeComment/CommentInput.vue
@@ -1,20 +1,28 @@
 <template>
-    <div class="flex gap-5">
-        <div class="w-12 h-12 rounded-full bg-slate-300">
+    <div class="flex gap-5 mb-4">
+        <div class="flex-shrink-0 w-16 h-16 rounded-full bg-slate-300">
             <img src="../../assets/default_user.png" alt="avatar" class="w-full h-auto overflow-hidden ">
         </div>
-        <div class="flex">
-            <div class="text-left w-96">
+        <div class="flex flex-1 md:flex-none md:basis-2/3">
+            <div class="w-full text-left md:w-96">
                 <button @click="openComment" class="p-2 border-2 border-solid rounded-lg border-amber-500 text-amber-500">留下您對餐廳的評論</button>
-                <Stars @score-update="updateScore" :resetScores="resetScores" class="my-2" />
+                <Stars class="my-2" />
                 <div class="flex flex-col" v-if="isExpanded">
-                    <input type="text" v-model="commentText" class="w-full h-20 border-2 border-solid rounded-sm" placeholder="發表用餐經驗">
+                    <textarea
+                        v-model="commentText"
+                        maxlength="200"
+                        class="w-full h-20 border-2 border-solid rounded-sm resize-none"
+                        placeholder="發表用餐經驗"
+                    ></textarea>
+                    <p v-if="commentText.length >= 1" class="text-sm text-slate-500">
+                        還可以輸入 {{ 200 - commentText.length }} 字
+                    </p>
                     <div class="flex items-center w-full h-10 my-2">
                         <input type="number" v-model="price" placeholder="輸入用餐價格" class="flex-1 h-10 border-2 border-solid rounded-sm">
-                        <label class="ml-2">元/人</label>
+                        <label class="ml-2">元 / 人</label>
                     </div>
-                    <UploadPic @pics-update="updatePics" :resetPics="resetPics" />
-                    <button @click="submitComment" class="w-full p-2 my-2 mr-4 font-bold rounded-lg shadow text-amber-500">送出評論</button>
+                    <UploadPic />
+                    <button @click="submitComment" class="w-full p-2 my-2 font-bold rounded-lg shadow md:flex-1 text-amber-500">送出評論</button>
                 </div>
             </div>
         </div>
@@ -22,28 +30,22 @@
 </template>
 
 <script setup>
-import { ref, resolveDirective } from 'vue'
+import { ref } from 'vue'
 import Stars from "./Stars.vue"
 import UploadPic from "./UploadPic.vue"
+import { useStarsStore } from '../../stores/starStore';
+import { useCommentStore } from '../../stores/commentStore';
+import { usePicStore } from '../../stores/picStore';
 
 const time = new Date()
 const price = ref('')
-const score = ref('')
-const pictures = ref([])
 const commentText = ref('')
 let isExpanded = ref(false)
-let resetPics = ref(false)
-let resetScores = ref(false)
 
-const updateScore = (newScore) => {
-    score.value = newScore;
-};
-const updatePics = (pics) => {
-    pictures.value = pics
-}
-
-const emit = defineEmits(['submitComment'])
-const comment = ref({})
+// 引入 Pinia Store
+const starsStore = useStarsStore()
+const commentStore = useCommentStore()
+const picStore = usePicStore()
 
 const submitComment = () => {
     if(!commentText.value.trim()){
@@ -51,29 +53,26 @@ const submitComment = () => {
         return
     }
 
-    comment.value = {
+    const newComment = {
         id: crypto.randomUUID(),
         userName: "Julie Wang",
         avatar: 'https://cats.com/wp-content/uploads/2024/05/A-long-haired-orange-cat-looks-up-with-gentle-eyes-compressed.jpg',
         reviewNum: 999,
         commentTime: time.toLocaleDateString(),
-        star: score.value,
+        star: starsStore.selectIndex,
         price: price.value,
         commentText: commentText.value,
-        pictures: pictures.value,
+        pictures: picStore.pictures,
         likeStatus: false,
         likeHint: "表示讚賞",
         likeNum: 0
     }
-    console.log("Submit comments:", comment.value)
-    emit('submitComment', comment.value)
+    commentStore.addComment(newComment); // 使用 Pinia Store 更新評論
+    //重置輸入框
     commentText.value = ''
     price.value = ''
-    score.value = ''
-    pictures.value = []
-    resetPics.value = true // 通知子元件重置
-    setTimeout(() => (resetPics.value = false), 0) // 恢復狀態
-    resetScores.value = true
+    picStore.resetPic() // 重置圖片
+    starsStore.resetStars() // 重置星星狀態
 }
 
 const openComment = () => {

--- a/src/components/storeComment/PreviousReview.vue
+++ b/src/components/storeComment/PreviousReview.vue
@@ -1,13 +1,13 @@
 <template>
-    <div class="flex flex-col gap-x-5" v-if="comments.length > 0">
-        <div class="flex gap-x-5 gap-y-6" v-for="(comment, index) in comments" :key="index">
-            <div class="w-12 h-12 overflow-hidden rounded-full bg-slate-300">
+    <div class="flex flex-col gap-y-5" v-if="comments.length > 0">
+        <div class="flex flex-row gap-x-5 py-2.5 w-full max-w-screen-lg mx-auto md:px-0" v-for="(comment, index) in comments" :key="index">
+            <div class="flex-shrink-0 w-16 h-16 overflow-hidden rounded-full bg-slate-300">
                 <img :src="comment.avatar ? comment.avatar : '/src/assets/default_user.png'" alt="avatar" class="object-cover w-full h-full">
             </div>
-            <div class="flex flex-col text-left">
-                <a class="font-bold" href="#">{{ comment.userName }}<span>（{{ comment.reviewNum }} 則評論）</span></a>
+            <div class="flex flex-col flex-1 w-0 text-left">
+                <router-link to="/user" class="font-bold cursor-pointer text-amber-500">{{ comment.userName }}（{{ comment.reviewNum }} 則評論）</router-link>
                 <div class="flex gap-3">
-                    <span v-if="comment.star" class="p-1 text-sm text-white rounded-full bg-amber-500">{{ comment.star }}.0 ★</span>
+                    <span v-if="comment.star" class="px-2 py-1 text-sm font-bold text-white rounded-full bg-amber-500">{{ comment.star }}.0 ★</span>
                     <p v-if="comment.price">均消價位：${{ comment.price }}</p>
                 </div>
                 <p class="text-slate-500">評論日期：{{ comment.commentTime }}</p>
@@ -16,32 +16,44 @@
                     <button @click="toggleLike(comment)" class="p-2 rounded-lg shadow ">{{ comment.likeHint }}</button>
                     <button class="p-2 ml-2 rounded-lg shadow" @click="shareComment(comment)">分享評論</button>
                 </div>
-                <div class="flex gap-4">
-                    <div v-for="(imageUrl, index) in comment.pictures" :key="index" class="overflow-hidden w-52 h-52">
-                        <img :src="imageUrl" class="w-full my-2">
+                <div class="flex gap-4 mt-4 overflow-x-auto scrollbar-hide" style="scroll-snap-type: x mandatory;">
+                    <div v-for="(imageUrl, index) in comment.pictures" :key="index" class="flex-shrink-0 w-32 h-32 overflow-hidden">
+                        <img :src="imageUrl" @click="showPopup(imageUrl)" class="object-cover w-full h-full cursor-pointer">
                     </div>
                 </div>
+            </div>
+        </div>
+        <!-- Popup -->
+        <div v-if="popupImage" class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70">
+            <div class="relative w-full max-w-screen-md">
+                <span
+                class="absolute p-2 text-black bg-white rounded-full shadow cursor-pointer top-2 right-2"
+                @click="closePopup">
+                ✕
+                </span>
+                <img :src="popupImage" class="object-contain w-1/2 m-auto max-h-1/2" />
             </div>
         </div>
     </div>
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
+import { useCommentStore } from '../../stores/commentStore'
 
-// 讚數
-let likeNum = ref(0)
-let likeHint = ref('表示讚賞')
-let likeStatus = ref(false)
+// 從 Store 獲取評論數據
+const commentStore = useCommentStore()
+const comments = computed(() => commentStore.comments)
 
-const props = defineProps({
-    comments: {
-        type: Array,
-        default: () => [],
-    }
-})
-console.log("Received comments:", props.comments)
+// 圖片popup
+const popupImage = ref(null)
 
+const showPopup = (imageUrl) => {
+    popupImage.value = imageUrl;
+}
+const closePopup = () => {
+      popupImage.value = null;
+}
 
 // 讚數+1
 const toggleLike = (comment) => {

--- a/src/components/storeComment/Stars.vue
+++ b/src/components/storeComment/Stars.vue
@@ -2,66 +2,33 @@
     <div class="flex gap-2" @mouseleave="resetHoverIndex">
         <div 
         class="w-8 h-8 rounded-full cursor-pointer"
-        v-for="starIndex in totalStars"
+        v-for="starIndex in starsStore.totalStars"
         :key="starIndex"
         :class="{
-        'bg-slate-200': starIndex > hoverIndex && starIndex > selectIndex,
-        'bg-amber-500': starIndex <= hoverIndex || starIndex <= selectIndex
+        'bg-slate-200': starIndex > starsStore.hoverIndex && starIndex > starsStore.selectIndex,
+        'bg-amber-500': starIndex <= starsStore.hoverIndex || starIndex <= starsStore.selectIndex
         }"
         @mouseenter="setHoverIndex(starIndex)"
         @click="starClick(starIndex)"
         ></div>
-        <p>{{ hint[0] }}
-            <label v-if="hint[1]" class="p-1 text-sm text-white rounded-full bg-amber-500">{{ hint[1] }}</label>
+        <p>{{ starsStore.hint[0] }}
+            <label v-if="starsStore.hint[1]" class="px-2 py-1 text-sm text-white rounded-full bg-amber-500">{{ starsStore.hint[1] }}</label>
         </p>
     </div>
 </template>
 
 <script setup>
-import { computed, ref, watch } from 'vue'
-const hints = ['很不喜歡', '需要加油', '普通', '還不錯', '非常推薦'];
-const scores = ['1.0 ★', '2.0 ★', '3.0 ★', '4.0 ★', '5.0 ★']
-const totalStars = 5
-const hoverIndex = ref(0)
-const selectIndex = ref(0)
-
-// 監視
-watch(selectIndex, (newScore) => {
-    emit('score-update', newScore)
-})
-
-const emit = defineEmits(['score-update'])
-
-// 重置
-const props = defineProps({
-    resetScores: Boolean
-})
-
-watch(() => props.resetStatus, (newValue) => {
-    if (newValue) {
-        imageUrls.value = [] // 清空本地圖片
-    }
-})
-
-// 評分標籤
-const hint = computed(() => {
-    if (hoverIndex.value > 0) {
-        return [hints[hoverIndex.value - 1], scores[hoverIndex.value - 1]]
-    }
-    if (selectIndex.value > 0) {
-        return [hints[selectIndex.value - 1], scores[selectIndex.value - 1]]
-    }
-    return ['給予評分']
-})
+import { useStarsStore } from '../../stores/starStore'
+const starsStore = useStarsStore()
 
 const resetHoverIndex = () => {
-    hoverIndex.value = 0
+    starsStore.setHoverIndex(0)
 }
 
 const setHoverIndex = (index) => {
-    hoverIndex.value = index
+    starsStore.setHoverIndex(index)
 }
 const starClick = (index) => {
-    selectIndex.value = index
+    starsStore.setSelectIndex(index)
 }
 </script>

--- a/src/components/storeComment/StoreComment.vue
+++ b/src/components/storeComment/StoreComment.vue
@@ -1,21 +1,14 @@
 <template>
-  <div>
-    <CommentInput @submitComment="addComment" />
-    <PreviousReview :comments="comments" />
+  <div class="mt-10">
+    <CommentInput />
+    <PreviousReview />
   </div>
 </template>
 
 <script setup>
-import { ref } from 'vue'
 // 留言框
 import CommentInput from './CommentInput.vue'
 // 先前的評論
 import PreviousReview from './PreviousReview.vue'
-
-const comments = ref([])
-
-const addComment = (newComment) => {
-  comments.value.unshift(newComment)
-}
 </script>
 

--- a/src/components/storeComment/UploadPic.vue
+++ b/src/components/storeComment/UploadPic.vue
@@ -1,12 +1,12 @@
 <template>
-    <div class="wrap">
+    <div>
         <!-- 用隱藏的 input type=file 來觸發檔案選擇器 -->
         <input type="file" ref="fileInput" @change="handleFileChange" hidden>
         <!-- 圖片預覽 -->
-        <div v-if="imageUrls" class="flex gap-4">
-            <div v-for="(imageUrl, index) in imageUrls" :key="index" class="relative overflow-hidden w-52 h-52">
-                <div @click="deleteImg" class="absolute text-lg font-bold leading-7 text-center text-white bg-red-500 rounded-full cursor-pointer w-7 h-7 top-2 right-2 ">X</div>
-                <img :src="imageUrl" class="w-full my-2">
+        <div v-if="pictures.length" class="flex flex-wrap">
+            <div v-for="(imageUrl, index) in pictures" :key="index" class="relative w-1/3 p-1 overflow-hidden md:w-1/2">
+                <div @click="deleteImg(index)" class="absolute text-lg font-bold leading-7 text-center text-white bg-red-500 rounded-full cursor-pointer w-7 h-7 top-2 right-2">X</div>
+                <img :src="imageUrl" >
             </div>
         </div>
         <!-- 點擊按鈕上傳圖片 -->
@@ -16,43 +16,33 @@
             'my-2 text-white bg-amber-500 ':!isDisabled,
         }"
         class="w-full p-2 mr-4 font-bold rounded-lg shadow"
-        :disabled="isDisabled">附上相片（至多十張）</button>
+        :disabled="isDisabled">附上相片（至多五張）</button>
     </div>
 </template>
+
 <script setup>
-import { computed, ref, watch } from  'vue'
+import { computed, ref } from  'vue'
+import { usePicStore } from '../../stores/picStore'
+
+const picStore = usePicStore()
 const fileInput = ref(null)
-const imageUrls = ref([])
-const maxImages = 2
-let isDisabled = computed(() => imageUrls.value.length >= maxImages)
+const pictures = computed(() => picStore.pictures)
+const isDisabled = computed(() => picStore.isDisabled)
 
 const triggerFileInput = () => {
     fileInput.value.click()
 }
 
-const props = defineProps({
-    resetPics: Boolean
-})
-
-watch(() => props.resetStatus, (newValue) => {
-    if (newValue) {
-        imageUrls.value = [] // 清空本地圖片
-    }
-})
-
-const deleteImg = () => {
-    imageUrls.value.pop()
+const deleteImg = (index) => {
+    picStore.removePic(index)
 }
-
-const emit = defineEmits(['pics-update'])
 
 const handleFileChange = (e) => {
     const file = e.target.files[0]
     if(file){
         const reader = new FileReader()
         reader.onload = (event) => {
-            imageUrls.value.push(event.target.result)
-            emit('pics-update', imageUrls.value)
+            picStore.addPic(event.target.result)
         }
         reader.readAsDataURL(file)
     }

--- a/src/components/userProfile/UserTab.vue
+++ b/src/components/userProfile/UserTab.vue
@@ -83,29 +83,7 @@
         <!-- 餐廳評論 -->
         <div v-show="activeTab === 'review'">
             <h2 class="my-8 font-bold text-left text-amber-500">Julie Wang 的 5 則評論</h2>
-            <!-- PreviousReview -->
-            <div class="flex flex-col gap-x-5">
-                <div class="flex gap-x-5 gap-y-6">
-                    <div class="w-12 h-12 overflow-hidden rounded-full bg-slate-300">
-                        <img src="/src/assets/default_user.png" alt="avatar" class="object-cover w-full h-full">
-                    </div>
-                    <div class="flex flex-col text-left">
-                        <a class="font-bold" href="#">Julie Wang<span>（5 則評論）</span></a>
-                        <div class="flex gap-3">
-                        <span class="p-1 text-sm text-white rounded-full bg-amber-500">5.0 ★</span>
-                        <p>均消價位：$ 400</p>
-                        </div>
-                        <p class="text-slate-500">2024/11/28 到訪了<a href="#">涓豆腐</a></p>
-                        <p class="my-3">第一次吃涓豆腐，真的很好吃！<br>小菜都很有水準，而且可以一直續<br>石鍋飯很Q彈，湯頭很好喝，最喜歡雪濃湯的湯頭<br>甜點也很好吃，冰淇淋跟鬆餅很配<br>跟朋友去聚餐的好選擇
-                        </p>
-                        <div>
-                        <button class="p-2 rounded-lg shadow ">表示讚賞</button>
-                        <button class="p-2 ml-2 rounded-lg shadow">分享評論</button>
-                        </div>
-                        <div class="flex gap-4 bg-slate-400"></div>
-                    </div>
-                </div>
-            </div>
+            <PreviousReview/>
         </div>
     </div>
 </template>
@@ -113,6 +91,7 @@
 <script setup>
 import { ref } from 'vue';
 import KeepList from './KeepList.vue';
+import PreviousReview from '../storeComment/PreviousReview.vue';
 const activeTab = ref('review')
 
 const clickReview = () => activeTab.value = 'review'

--- a/src/stores/commentStore.js
+++ b/src/stores/commentStore.js
@@ -1,0 +1,14 @@
+import { defineStore } from "pinia"
+
+export const useCommentStore = defineStore('commentStore',
+    {
+        state: () => ({
+            comments: [],
+        }),
+        actions: {
+            addComment(newComment){
+                this.comments.unshift(newComment)
+            }
+        }
+    }
+)

--- a/src/stores/picStore.js
+++ b/src/stores/picStore.js
@@ -1,0 +1,31 @@
+import { defineStore } from "pinia"
+import { ref, computed } from "vue"
+
+export const usePicStore = defineStore('picture', () => {
+    const maxImages = ref(5)
+    const pictures = ref([])
+    const isDisabled = computed(() => pictures.value.length >= maxImages.value)
+
+    const addPic = (imageUrl) => {
+        if(pictures.value.length < maxImages.value){
+            pictures.value.push(imageUrl)
+        } else {
+            alert(`最多只能上傳 ${maxImages.value} 張圖片`)
+        }
+    }
+    const removePic = (index) => {
+        pictures.value.splice(index, 1)
+    }
+    const resetPic = () => {
+        pictures.value = []
+    }
+
+    return{
+        maxImages,
+        isDisabled,
+        pictures,
+        addPic,
+        removePic,
+        resetPic
+    }
+})

--- a/src/stores/starStore.js
+++ b/src/stores/starStore.js
@@ -1,0 +1,49 @@
+import { defineStore } from 'pinia';
+import { ref, computed } from 'vue';
+
+export const useStarsStore = defineStore('stars', () => {
+  const totalStars = 5;
+  const hoverIndex = ref(0);
+  const selectIndex = ref(0);
+
+  const hints = ['很不喜歡', '需要加油', '普通', '還不錯', '非常推薦'];
+  const scores = ['1.0 ★', '2.0 ★', '3.0 ★', '4.0 ★', '5.0 ★'];
+
+  const hint = computed(() => {
+    if (hoverIndex.value > 0) {
+      return [hints[hoverIndex.value - 1], scores[hoverIndex.value - 1]];
+    }
+    if (selectIndex.value > 0) {
+      return [hints[selectIndex.value - 1], scores[selectIndex.value - 1]];
+    }
+    return ['給予評分'];
+  });
+
+  const resetHoverIndex = () => {
+    hoverIndex.value = 0;
+  };
+
+  const setHoverIndex = (index) => {
+    hoverIndex.value = index;
+  };
+
+  const setSelectIndex = (index) => {
+    selectIndex.value = index;
+  };
+
+  const resetStars = () => {
+    hoverIndex.value = 0;
+    selectIndex.value = 0;
+  };
+
+  return {
+    totalStars,
+    hoverIndex,
+    selectIndex,
+    hint,
+    resetHoverIndex,
+    setHoverIndex,
+    setSelectIndex,
+    resetStars,
+  };
+});

--- a/src/views/StorePage.vue
+++ b/src/views/StorePage.vue
@@ -236,9 +236,9 @@ document.addEventListener('click', handleDocumentClick);
                     </a>
                     <!-- 評價部分 -->
                     <a :href="googleMapsUri" target="_blank" class="cursor-pointer hover:opacity-90">
-                        <div class="mt-2 w-40">
-                            <div class="flex items-center mb-1 py-1 rounded bg-amber-500 justify-center ">
-                                <font-awesome-icon :icon="['fab', 'google']" class="text-blue-600 w-4 h-4 mr-1"/>
+                        <div class="w-40 mt-2">
+                            <div class="flex items-center justify-center py-1 mb-1 rounded bg-amber-500 ">
+                                <font-awesome-icon :icon="['fab', 'google']" class="w-4 h-4 mr-1 text-blue-600"/>
                                 <div class="flex items-center">
                                     <span class="text-sm">評價:</span>
                                     <span class="text-sm text-gray-500">{{ userRatingCount }}+</span>
@@ -285,28 +285,29 @@ document.addEventListener('click', handleDocumentClick);
                 </div>
             </div>
 
-
+            <!-- 店家評論 -->
+            <StoreComment/>
             <!-- 相似餐廳區 -->
                 <div class="mt-10 text-gray-700 md:w-[900px] mx-auto">
                     <h3 class="mb-2 text-2xl font-bold">{{ storeName }} 的相似餐廳</h3>
                     <div v-if="displayRestaurants && displayRestaurants.length" class="flex items-center justify-center space-x-4">
                         <!-- 左側切換按鈕 -->
-                        <button @click="handlePrevGroup" class="p-2 rounded-full bg-gray-200 hover:bg-gray-300">
+                        <button @click="handlePrevGroup" class="p-2 bg-gray-200 rounded-full hover:bg-gray-300">
                             ←
                         </button>
 
                         <!-- 餐廳展示區 -->
                         <div class="relative w-full overflow-hidden">
                             <transition-group name="slide" tag="div" class="flex">
-                                <div v-for="(restaurant, index) in displayRestaurants" :key="restaurant.uniqueId || index" class="flex-shrink-0 w-1/2 md:w-1/3 px-2">
+                                <div v-for="(restaurant, index) in displayRestaurants" :key="restaurant.uniqueId || index" class="flex-shrink-0 w-1/2 px-2 md:w-1/3">
                                     <div class="bg-white rounded-lg shadow-md mb-4 max-w-[250px] mx-auto">
                                         <div class="h-40 overflow-hidden">
-                                            <img v-if="restaurant?.photoUrl" :src="restaurant.photoUrl" :alt="restaurant.name" class="w-full h-40 object-cover rounded-t-lg" />
+                                            <img v-if="restaurant?.photoUrl" :src="restaurant.photoUrl" :alt="restaurant.name" class="object-cover w-full h-40 rounded-t-lg" />
                                         </div>
                                         <div class="p-4">
-                                            <h4 class="font-bold text-lg truncate max-md:text-center">{{ restaurant?.name }}</h4>
-                                            <div class="flex flex-col md:flex-row justify-between items-center mt-2 gap-2">
-                                                <p class="text-white bg-amber-500 px-2 rounded-full w-fit text-center">
+                                            <h4 class="text-lg font-bold truncate max-md:text-center">{{ restaurant?.name }}</h4>
+                                            <div class="flex flex-col items-center justify-between gap-2 mt-2 md:flex-row">
+                                                <p class="px-2 text-center text-white rounded-full bg-amber-500 w-fit">
                                                     評分: {{ restaurant?.rating }}★
                                                 </p>
                                                 <p class="text-sm text-gray-400">
@@ -320,13 +321,13 @@ document.addEventListener('click', handleDocumentClick);
                         </div>
 
                         <!-- 右側切換按鈕 -->
-                        <button @click="handleNextGroup" class="p-2 rounded-full bg-gray-200 hover:bg-gray-300">
+                        <button @click="handleNextGroup" class="p-2 bg-gray-200 rounded-full hover:bg-gray-300">
                             →
                         </button>
                     </div>
 
                     <!-- 如果沒有數據顯示加載狀態 -->
-                    <div v-else class="text-center py-4">
+                    <div v-else class="py-4 text-center">
                         正在加載餐廳資料...
                     </div>
 
@@ -346,7 +347,7 @@ document.addEventListener('click', handleDocumentClick);
                     <!-- 左側切換按鈕 -->
                     <button 
                     @click="handlePrevRecommendedGroup"
-                    class="p-2 rounded-full bg-gray-200 hover:bg-gray-300"
+                    class="p-2 bg-gray-200 rounded-full hover:bg-gray-300"
                     >
                     ←
                     </button>
@@ -368,15 +369,15 @@ document.addEventListener('click', handleDocumentClick);
                                 v-if="restaurant?.photoUrl" 
                                 :src="restaurant.photoUrl" 
                                 :alt="restaurant.name" 
-                                class="w-full h-40 object-cover rounded-t-lg"
+                                class="object-cover w-full h-40 rounded-t-lg"
                                 />
                             </div>
                             <div class="p-4">
-                                <h4 class="font-bold text-lg truncate max-md:text-center">
+                                <h4 class="text-lg font-bold truncate max-md:text-center">
                                 {{ restaurant?.name }}
                                 </h4>
-                                <div class="flex flex-col md:flex-row justify-between items-center mt-2 gap-2">
-                                <p class="text-white bg-amber-500 px-2 rounded-full w-fit text-center">
+                                <div class="flex flex-col items-center justify-between gap-2 mt-2 md:flex-row">
+                                <p class="px-2 text-center text-white rounded-full bg-amber-500 w-fit">
                                     評分: {{ restaurant?.rating }}★
                                 </p>
                                 <p class="text-sm text-gray-400">
@@ -392,14 +393,14 @@ document.addEventListener('click', handleDocumentClick);
                     <!-- 右側切換按鈕 -->
                     <button 
                     @click="handleNextRecommendedGroup"  
-                    class="p-2 rounded-full bg-gray-200 hover:bg-gray-300"
+                    class="p-2 bg-gray-200 rounded-full hover:bg-gray-300"
                     >
                     →
                     </button>
                 </div>
 
                     <!-- 加載狀態 -->
-                    <div v-else class="text-center py-4">
+                    <div v-else class="py-4 text-center">
                     正在加載餐廳資料...
                     </div>
 


### PR DESCRIPTION
fix issue #9 
1. 原本店家評論的新增、上傳圖片、顯示是用 props 與 emit 寫，因為評論會出現在多個頁面（首頁、店家頁、個人頁），所以改用 pinia 管理比較方便
2. 在沒有重新整理的狀態下，店家頁的評論跟個人頁看到的評論紀錄一致（資料未寫到資料庫，所以重新整理會消失）
3. 評論設定字數限制 200 字

<img width="523" alt="截圖 2024-12-13 凌晨12 56 51" src="https://github.com/user-attachments/assets/f05c96ca-7f97-43bc-9def-87edfcc13abf" />

4. 圖片最多上傳 5 張

<img width="441" alt="截圖 2024-12-13 凌晨12 58 29" src="https://github.com/user-attachments/assets/e155e8ad-6200-4609-a911-01876f150993" />

5. 修改 RWD、圖片可以往左滑、點擊圖片會看到放大的popup

手機

<img width="500" alt="截圖 2024-12-13 凌晨1 01 07" src="https://github.com/user-attachments/assets/8239dfd3-7d27-4417-b00e-cf808582ee7b" />

大螢幕

<img width="995" alt="截圖 2024-12-13 凌晨1 01 52" src="https://github.com/user-attachments/assets/8668a949-042a-416b-ad22-c0a6abd76d70" />


